### PR TITLE
In losses_utils, the mask_sequences should work when sequence length is not None

### DIFF
--- a/texar/losses/losses_utils.py
+++ b/texar/losses/losses_utils.py
@@ -98,7 +98,7 @@ def mask_and_reduce(sequence,
     if time_major:
         sequence = rnn._transpose_batch_time(sequence)
 
-    if sequence_length is None:
+    if sequence_length is not None:
         sequence = mask_sequences(sequence, sequence_length, dtype=dtype,
                                   time_major=False, tensor_rank=rank)
 


### PR DESCRIPTION
In losses_utils, the mask_and_reduce function    
```
if sequence_length is None:
        sequence = mask_sequences(sequence, sequence_length, dtype=dtype,
                                  time_major=False, tensor_rank=rank)
```
I think this should be changed to `if sequence_length is not None`