### PR TITLE
remove BOS of true samples in discriminator and change pg loss to negative

### DIFF
--- a/examples/seqgan/seqgan_train.py
+++ b/examples/seqgan/seqgan_train.py
@@ -109,13 +109,14 @@ def _main(_):
     d_embedder = tx.modules.WordEmbedder(vocab_size=vocab_size,
                                          hparams=config.emb_hparams)
 
-    r_logits, _ = discriminator(d_embedder(data_batch["text_ids"]))
-    f_logits, _ = discriminator(d_embedder(infer_sample_ids))
+    r_logits, _ = discriminator(d_embedder(data_batch["text_ids"][:, 1:]),
+                                sequence_length=data_batch["length"] - 1)
+    f_logits, _ = discriminator(d_embedder(infer_sample_ids), sequence_length=sequence_length)
 
     r_loss = tx.losses.sequence_sigmoid_cross_entropy(
-        labels=tf.ones_like(data_batch["text_ids"], dtype=tf.float32),
+        labels=tf.ones_like(data_batch["text_ids"][:, 1:], dtype=tf.float32),
         logits=tf.squeeze(r_logits),
-        sequence_length=data_batch["length"])  # r_preds -> 1.
+        sequence_length=data_batch["length"] - 1)  # r_preds -> 1.
     f_loss = tx.losses.sequence_sigmoid_cross_entropy(
         labels=tf.zeros_like(infer_sample_ids, dtype=tf.float32),
         logits=tf.squeeze(f_logits),

--- a/examples/seqgan/seqgan_train.py
+++ b/examples/seqgan/seqgan_train.py
@@ -146,8 +146,8 @@ def _main(_):
                                   hparams=config.update_opt_hparams)
     reward = tx.losses.discount_reward(
         reward, sequence_length=tf.squeeze(sequence_length), tensor_rank=2)
-    update_loss = tf.reduce_mean(tf.log(infer_logits) *
-                                 tf.expand_dims(reward, -1))
+    update_loss = -tf.reduce_mean(tf.log(infer_logits) *
+                                  tf.expand_dims(reward, -1))
     update_loss.set_shape(())
     gen_op = tx.core.get_train_op(update_loss,
                                   global_step=global_step,


### PR DESCRIPTION
In seqgan_train example, the pretrain discriminator and adversarial training:
    1. the true sample passed to the discriminator has the BOS token. But the generator won't generate this BOS token which is used as input. So it's better to remove  this token to avoid the deviation
    2. the sequence_length parameter is set to avoid the extra computation
    3. the pg loss should be -reward*log(p), so change the `update_loss` to negative  