### PR TITLE
Create .readthedocs.yml to allow readthedocs build successfully 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,6 @@
+version: 2
+
+python:
+  version: 3.6
+  install:
+     - requirements: docs/requirements.txt


### PR DESCRIPTION
- The problem: 
readthedocs uses python 3.7 by default to install dependencies and fails at installing latest tensorflow

- The fix: 
added `readthedocs.yml` to force readthedocs use python 3.6