### PR TITLE
Update docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,5 +12,5 @@ pyyaml
 funcsigs
 packaging
 
-tensorflow >= 1.10.0, < 2.0.0
+tensorflow == 1.14.0
 tensorflow-probability >= 0.3.0, < 0.8.0


### PR DESCRIPTION
`docs` is failing because the wheel file of TensorFlow 1.15.0 is quite large (412.3MB). Use TensorFlow 1.14.0 (109.2MB) instead. 