### PR TITLE
Minor Fix on seq2seq_attn

### DIFF
--- a/examples/seq2seq_attn/README.md
+++ b/examples/seq2seq_attn/README.md
@@ -11,7 +11,7 @@ Two example datasets are provided:
   * toy_copy: A small toy autoencoding dataset from [TF Seq2seq toolkit](https://github.com/google/seq2seq/tree/2500c26add91b079ca00cf1f091db5a99ddab9ae).
   * iwslt14: The benchmark [IWSLT2014](https://sites.google.com/site/iwsltevaluation2014/home) (de-en) machine translation dataset, following [(Ranzato et al., 2015)](https://arxiv.org/pdf/1511.06732.pdf) for data pre-processing.
 
-Download the data with the following cmds:
+Download the data with the following commands:
 
 ```
 python prepare_data.py --data toy_copy
@@ -20,15 +20,16 @@ python prepare_data.py --data iwslt14
 
 ### Train the model ###
 
-Train the model with the following cmd:
+Train the model with the following command:
 
 ```
-python seq2seq_attn.py --config_model config_model --config_data config_toy_copy
+python seq2seq_attn.py --config-model config_model --config-data config_toy_copy
 ```
 
 Here:
-  * `--config_model` specifies the model config. Note not to include the `.py` suffix.
-  * `--config_data` specifies the data config.
+
+  * `--config-model` specifies the model config. Note not to include the `.py` suffix.
+  * `--config-data` specifies the data config.
 
 [config_model.py](./config_model.py) specifies a single-layer seq2seq model with Luong attention and bi-directional RNN encoder. Hyperparameters taking default values can be omitted from the config file. 
 
@@ -36,5 +37,5 @@ For demonstration purpose, [config_model_full.py](./config_model_full.py) gives 
 
 ## Results ##
 
-On the IWSLT14 dataset, using original target texts as reference(no  `<UNK>`  in the reference), the model achieves `BLEU = 26.44 ± 0.18` .
+On the IWSLT14 dataset, using original target texts as reference (no  `<UNK>`  in the reference), the model achieves `BLEU = 26.44 ± 0.18` .
 

--- a/examples/seq2seq_attn/config_iwslt14.py
+++ b/examples/seq2seq_attn/config_iwslt14.py
@@ -1,6 +1,5 @@
-
 num_epochs = 15
-display = 500
+display = 50
 
 source_vocab_file = './data/iwslt14/vocab.de'
 target_vocab_file = './data/iwslt14/vocab.en'

--- a/examples/seq2seq_attn/config_toy_copy.py
+++ b/examples/seq2seq_attn/config_toy_copy.py
@@ -1,4 +1,3 @@
-
 num_epochs = 4
 display = 50
 

--- a/examples/seq2seq_attn/prepare_data.py
+++ b/examples/seq2seq_attn/prepare_data.py
@@ -25,7 +25,7 @@ flags.DEFINE_string("data", "iwslt14", "Data to download [iwslt14|toy_copy]")
 FLAGS = flags.FLAGS
 
 
-def prepare_data():
+def main():
     """Downloads data.
     """
     if FLAGS.data == 'iwslt14':
@@ -44,12 +44,6 @@ def prepare_data():
             extract=True)
     else:
         raise ValueError('Unknown data: {}'.format(FLAGS.data))
-
-
-def main():
-    """Entrypoint.
-    """
-    prepare_data()
 
 
 if __name__ == '__main__':

--- a/examples/seq2seq_attn/seq2seq_attn.py
+++ b/examples/seq2seq_attn/seq2seq_attn.py
@@ -16,19 +16,22 @@
 
 # pylint: disable=invalid-name, too-many-arguments, too-many-locals
 
+import argparse
 import importlib
 import tensorflow as tf
 import texar.tf as tx
 
-flags = tf.flags
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '--config-model', type=str, default="config_model",
+    help="The model config.")
+parser.add_argument(
+    '--config-data', type=str, default="config_iwslt14",
+    help="The dataset config.")
+args = parser.parse_args()
 
-flags.DEFINE_string("config_model", "config_model", "The model config.")
-flags.DEFINE_string("config_data", "config_iwslt14", "The dataset config.")
-
-FLAGS = flags.FLAGS
-
-config_model = importlib.import_module(FLAGS.config_model)
-config_data = importlib.import_module(FLAGS.config_data)
+config_model = importlib.import_module(args.config_model)
+config_data = importlib.import_module(args.config_data)
 
 
 def build_model(batch, train_data):


### PR DESCRIPTION
`tf.flags` cannot handle options containing a hyphen in the middle. Use `argparse` instead.